### PR TITLE
Set human readable pacman output : no progress bar in scripts

### DIFF
--- a/dockerfiles/vm-archlinux.Dockerfile
+++ b/dockerfiles/vm-archlinux.Dockerfile
@@ -1,6 +1,6 @@
 FROM archlinux:latest
 
-RUN pacman-key --init && pacman-key --populate && pacman -Syu --noconfirm wget sudo
+RUN pacman-key --init && pacman-key --populate && pacman -Syu --noconfirm --noprogressbar wget sudo
 RUN wget -O /tmp/qubes-repo-archlinux-key.asc https://raw.githubusercontent.com/QubesOS/qubes-builderv2/main/qubesbuilder/plugins/chroot_archlinux/keys/qubes-repo-archlinux-key.asc
 RUN pacman-key --add - < /tmp/qubes-repo-archlinux-key.asc
 RUN pacman-key --lsign "$(gpg --with-colons --show-key /tmp/qubes-repo-archlinux-key.asc -| grep ^fpr: | cut -d : -f 10)"

--- a/scripts/gitlab-installv2
+++ b/scripts/gitlab-installv2
@@ -45,7 +45,7 @@ def main(qubes_distribution: QubesDistribution, repository: Path):
         )
     elif qubes_distribution.fullname == "archlinux":
         pkgext = "pkg.tar.zst"
-        run_cmd = "pacman -Sy  && pacman -U --noconfirm"
+        run_cmd = "pacman -Sy --noprogressbar  && pacman -U --noconfirm --noprogressbar"
     else:
         raise CIError("Unsupported distribution!")
 


### PR DESCRIPTION
Add `--noprogressbar` to pacman to avoid unreadable progressbar in the logs.
Fixes : QubesOS/qubes-issues/issues/9172